### PR TITLE
PR-6180 Loosen dependency restrictions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ name = "asf_kerchunk_timeseries"
 authors = [
     {name = "Alaska Satellite Facility Discovery Team", email = "uaf-asf-discovery@alaska.edu"},
 ]
-description = """This package is a wrapper around [Kerchunk](https://github.com/fsspec/kerchunk) for generating 
-zarr stores for individual netcdf4/hdf5 files as well as consolidating spatially aligned zarr stores 
+description = """This package is a wrapper around [Kerchunk](https://github.com/fsspec/kerchunk) for generating
+zarr stores for individual netcdf4/hdf5 files as well as consolidating spatially aligned zarr stores
 into a single temporal zarr store, indexed by the source_file_name."""
 
 
@@ -20,17 +20,17 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "aiobotocore==2.15.1",
-    "zarr==2.18.2",
-    "kerchunk==0.2.6",
-    "s3fs==2024.9.0",
-    "ujson==5.10.0",
-    "h5py==3.12.1",
+    "aiobotocore",
+    "zarr~=2.18",
+    "kerchunk~=0.2.6",
+    "s3fs",
+    "ujson~=5.10",
+    "h5py~=3.6",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest==8.3.3",
+    "pytest~=8.3",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
We were running into some version conflicts when trying to install this into our lambda dependency layer. Together with https://github.com/asfadmin/mandible/pull/26 I was able to get it to install with these changes.

Here's the reasoning for these changes:

- `aiobotocore` Looks like this is only used to import the `AioSession` for typing purposes. This object has existed in the same module since the very first `aiobotocore` release so I just unpinned the version completely.
- `zarr` I didn't look into the API of this, just changed the version constraint to allow semver backwards compatible versions from what was pinned.
- `kerchunk` ditto
- `s3fs` Looks like s3fs only has one very simple API that has never really changed. Since they're using calver I also unpinned this completely.
- `ujson` same as zarr and kerchunk
- `h5py` same, but this was pinned to 3.6 just because that's what mandible pinning. Haven't checked the API compatibility with this code though. In practice 3.12 is getting installed so it doesn't matter if we pin to 3.6 or 3.12.