### PR TITLE
skips encoding step on generate_kerchunk_file_store(), leaves to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from asf_kerchunk_timeseries import generate_kerchunk_file_store
 netcdf_uri = 's3://bucket-name/path/to/netcdf/file_00_version_v0.3.nc'
 json_store_bytes = generate_kerchunk_file_store(netcdf_uri, netcdf_product_version='v0.3')
 
-fsspec.open('s3://destination_file/for/zarr/store_00.json', 'wb') as f:
+fsspec.open('s3://destination_file/for/zarr/store_00.zarr', 'wb') as f:
     f.write(json_store_bytes)
 ```
 ### Combine multiple netcdf4 Zarr Stores
@@ -34,11 +34,15 @@ with a list of the s3 uris for the temporal stack
 ``` python
 from asf_kerchunk_timeseries import generate_kerchunk_file_store_stack
 
-timestep_zarr_stores = ['s3://bucket-name/path/to/netcdf/file_00.json', ..., 's3://bucket-name/path/to/netcdf/file_01.json']
-json_timeseries_store_bytes = generate_kerchunk_file_store_stack(timestep_zarr_stores)
+timestep_zarr_stores = ['s3://bucket-name/path/to/netcdf/file_00.zarr', ..., 's3://bucket-name/path/to/netcdf/file_01.zarr']
+json_timeseries_store_dict = generate_kerchunk_file_store_stack(timestep_zarr_stores)
 
-fsspec.open('s3://destination_file/for/zarr/stack_00.json', 'wb') as f:
-    f.write(json_timeseries_store_bytes)
+# Run any post processing on the dict
+do_stuff(json_timeseries_store_dict)
+
+# Write the dict as byte encoding string to a file
+fsspec.open('s3://destination_file/for/zarr/stack_00.zarr', 'wb') as f:
+    f.write(json.dumps(json_timeseries_store_dict).encode())
 ```
 
 ### aiobotocore session

--- a/src/kerchunk_netcdf4.py
+++ b/src/kerchunk_netcdf4.py
@@ -21,7 +21,7 @@ def generate_kerchunk_file_store(
         "default_block_size": 1024 * 1024,
     },
     session: Optional[AioSession] = None,
-) -> bytes:
+) -> dict[str, Any]:
     """
     Creates a zarr store for the provided netcdf/h5 file using the kerchunk library
     and returns it as bytes
@@ -43,7 +43,8 @@ def generate_kerchunk_file_store(
 
     Returns
     -------
-    The encoded json zarr store for the provided `netcdf_uri` as bytes
+    The translated json zarr store for the provided `netcdf_uri` as bytes
+    (see kerchunk docs for spec https://fsspec.github.io/kerchunk/spec.html#version-1)
     """
     s3 = S3FileSystem(session=session)
 
@@ -82,7 +83,7 @@ def generate_kerchunk_file_store(
             dtype=np.dtype("datetime64[ns]"),
         )
 
-        return ujson.dumps(h5_chunks.translate()).encode()
+        return h5_chunks.translate()
 
 
 def generate_kerchunk_file_store_stack(

--- a/tests/test_kerchunk_netcdf4.py
+++ b/tests/test_kerchunk_netcdf4.py
@@ -1,3 +1,4 @@
+import ujson
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -88,9 +89,11 @@ def test_kerchunk_file_workflow(_mock_s3fs_ls, _mock_s3fs_open):
         zarr_store = f"{file}.zarr"
         with open(zarr_store, "wb") as f:
             f.write(
+                ujson.dumps(
                 generate_kerchunk_file_store(
                     file, netcdf_product_version="v0.0", fsspec_options=spec
                 )
+                ).encode()
             )
 
         test_data = xr.open_dataset(zarr_store, engine="kerchunk")


### PR DESCRIPTION
### Changed:
- `generate_kerchunk_file_store()` now returns dictionary, skipping encoding step
- README.md now uses '.zarr' instead of '.json'
- update test case
