### PR TITLE
`generate_kerchunk_file_store_stack()` returns dict, remove ujson dependency

### DIFF
--- a/.github/workflows/ruff-lint-workflow.yml
+++ b/.github/workflows/ruff-lint-workflow.yml
@@ -1,0 +1,20 @@
+on: [push]
+jobs:
+  Run-Ruff-Lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        pip install .[dev]
+    - name: Lint with Ruff
+      run: |
+        pip install ruff
+        ruff check --output-format=github .
+      continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -19,13 +19,20 @@ To generate a zarr store for a single netcdf4 file, run `generate_kerchunk_file_
 
 ``` python
 from asf_kerchunk_timeseries import generate_kerchunk_file_store
+import json
 
-netcdf_uri = 's3://bucket-name/path/to/netcdf/file_00_version_v0.3.nc'
-json_store_bytes = generate_kerchunk_file_store(netcdf_uri, netcdf_product_version='v0.3')
+netcdf_uri = 's3://bucket-name/path/to/netcdf/file_00_v0.3.nc'
+json_store_dict = generate_kerchunk_file_store(netcdf_uri, netcdf_product_version='v0.3')
 
-fsspec.open('s3://destination_file/for/zarr/store_00.zarr', 'wb') as f:
-    f.write(json_store_bytes)
+# Run any post processing on the dict
+# find-and-replace intermediate file uris, etc
+do_stuff(json_store_dict)
+
+# Write the dict as a byte encoded string to a file
+fsspec.open('s3://destination_file/for/zarr/store_00_v0.3.zarr', 'wb') as f:
+    f.write(json.dumps(json_store_dict).encode())
 ```
+
 ### Combine multiple netcdf4 Zarr Stores
 
 To generate a zarr store for a single stack, use `generate_kerchunk_file_store_stack()`
@@ -34,15 +41,11 @@ with a list of the s3 uris for the temporal stack
 ``` python
 from asf_kerchunk_timeseries import generate_kerchunk_file_store_stack
 
-timestep_zarr_stores = ['s3://bucket-name/path/to/netcdf/file_00.zarr', ..., 's3://bucket-name/path/to/netcdf/file_01.zarr']
-json_timeseries_store_dict = generate_kerchunk_file_store_stack(timestep_zarr_stores)
+timestep_zarr_stores = ['s3://bucket-name/path/to/netcdf/file_000_v0.3.zarr', ..., 's3://bucket-name/path/to/netcdf/file_400_v0.3.zarr']
+timeseries_store_dict = generate_kerchunk_file_store_stack(timestep_zarr_stores)
 
-# Run any post processing on the dict
-do_stuff(json_timeseries_store_dict)
-
-# Write the dict as byte encoding string to a file
 fsspec.open('s3://destination_file/for/zarr/stack_00.zarr', 'wb') as f:
-    f.write(json.dumps(json_timeseries_store_dict).encode())
+    f.write(json.dumps(timeseries_store_dict).encode())
 ```
 
 ### aiobotocore session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "zarr~=2.18",
     "kerchunk~=0.2.6",
     "s3fs",
-    "ujson~=5.10",
     "h5py~=3.6",
 ]
 

--- a/src/kerchunk_netcdf4.py
+++ b/src/kerchunk_netcdf4.py
@@ -2,7 +2,6 @@ import copy
 from typing import Any, Optional
 import numpy as np
 import zarr
-import ujson
 from kerchunk.hdf import SingleHdf5ToZarr
 from kerchunk.combine import MultiZarrToZarr, drop
 from aiobotocore.session import AioSession
@@ -97,7 +96,7 @@ def generate_kerchunk_file_store_stack(
     },
     netcdf4_bucket_session: Optional[AioSession] = None,
     zarr_bucket_session: Optional[AioSession] = None,
-) -> bytes:
+) -> dict[str, Any]:
     """
     Creates a consolidated zarr store from a list of zarr json stores.
     concatenated along the "secondary_datetime" axis and returns the new zarr json store as bytes
@@ -126,7 +125,7 @@ def generate_kerchunk_file_store_stack(
 
     Returns
     -------
-    The encoded combined json zarr store for the provided `zarr_uris` as bytes
+    The consolidated json zarr store for the provided `zarr_uris` as a dict
     """
     target_options = copy.deepcopy(fsspec_options)
     target_options["session"] = zarr_bucket_session
@@ -144,9 +143,8 @@ def generate_kerchunk_file_store_stack(
         identical_dims=["y", "x"],
         preprocess=drop_time,
     )
-    multi_zarr_store = zarr_chunks.translate()
 
-    return ujson.dumps(multi_zarr_store).encode()
+    return zarr_chunks.translate()
 
 
 def _add_data_variable(

--- a/tests/test_kerchunk_netcdf4.py
+++ b/tests/test_kerchunk_netcdf4.py
@@ -1,4 +1,4 @@
-import ujson
+import json
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -89,7 +89,7 @@ def test_kerchunk_file_workflow(_mock_s3fs_ls, _mock_s3fs_open):
         zarr_store = f"{file}.zarr"
         with open(zarr_store, "wb") as f:
             f.write(
-                ujson.dumps(
+                json.dumps(
                 generate_kerchunk_file_store(
                     file, netcdf_product_version="v0.0", fsspec_options=spec
                 )
@@ -113,7 +113,7 @@ def test_kerchunk_file_workflow(_mock_s3fs_ls, _mock_s3fs_open):
     uris = [f"{file}.zarr" for file in files]
     zarr_stack_store = "test_frame.zarr"
     with open(zarr_stack_store, "wb") as f:
-        f.write(generate_kerchunk_file_store_stack(uris, spec))
+        f.write(json.dumps(generate_kerchunk_file_store_stack(uris, spec)).encode())
 
     stack_data = xr.open_dataset(zarr_stack_store, engine="kerchunk")
     assert "source_file_name" in stack_data.coords


### PR DESCRIPTION
## Changed
- `generate_kerchunk_file_store_stack()` now returns dict instead of pre-encoded json bytes
- removes `ujson` as dependency
- update README.md
